### PR TITLE
Fix for mojave

### DIFF
--- a/Spotify Helper/Config/Info.plist
+++ b/Spotify Helper/Config/Info.plist
@@ -29,6 +29,8 @@
 		<key>NSAllowsArbitraryLoads</key>
 		<true/>
 	</dict>
+	<key>NSAppleEventsUsageDescription</key>
+	<string>Needs access to Automation to access Spotify Data</string>
 	<key>NSHumanReadableCopyright</key>
 	<string>Copyright © 2017 Lucid Development. All rights reserved.</string>
 	<key>NSMainStoryboardFile</key>


### PR DESCRIPTION
The app doesn't work on mojave because there is no key and text in the Info.plist explaining why we need access to apple script access.  
This pull request add this key and text